### PR TITLE
More toward dockerizing pipeline

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -11,11 +11,13 @@ MAINTAINER Julia Kodysh <julia326@gmail.com>
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get clean && \
     apt-get update && \
-    apt-get install --yes \
+    apt-get install --no-install-recommends --no-upgrade -y \
+        ca-certificates \
         curl \
         gawk \
         git \
         graphviz \
+        g++ \
         libfreetype6-dev \
         libx11-dev \
         make \
@@ -24,11 +26,14 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
         python-tk \
         python2.7-dev \
         python3.5-dev \
+        rsync \
         sudo \
         tcsh \
         wget \
         xvfb \
-        zlib1g-dev
+        zlib1g-dev && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # install wkhtmltopdf from source, this version comes with patched QT necessary for PDF gen
 RUN cd /tmp && \
@@ -86,28 +91,27 @@ RUN conda config --add channels r && \
     conda config --add channels conda-forge && \
     conda config --add channels bioconda && \
     conda create -n pgv \
-    bedtools \
+    bwa \
     cython \
     gatk==3.7 \
-    graphviz \
     java-jdk==8.0.92 \
     picard \
     pip \
     sambamba \
-    samtools \
     snakemake \
     star \
-    vcftools
+    vcftools && \
+    conda clean --all -y
 
 # most of the tools we're using are in the pgv environment; adding to PATH for convenience
 ENV PATH $PGV_BIN:$PATH
 
 # MuTect needs Java 1.7, while GATK and other things need Java 1.8.
 # Dealing with this by setting up a separate Conda environment, specifically for Java 7
-RUN conda create -n java7 java-jdk==7.0.91
+RUN conda create -n java7 java-jdk==7.0.91 && conda clean --all -y
 
 # Special sauce stuff
-RUN pip install vaxrank
+RUN pip install --ignore-installed vaxrank==0.7.12
 
 # needed for vaxrank reports to be reasonably formatted, otherwise kerning is off
 RUN curl https://pastebin.com/raw/AmfYN3er > $HOME/.fonts.conf
@@ -115,8 +119,29 @@ RUN curl https://pastebin.com/raw/AmfYN3er > $HOME/.fonts.conf
 # Copy the current directory contents into the container
 ADD . $HOME
 
+# set up Strelka config
+COPY strelka_config.txt $HOME/
+ENV STRELKA_CONFIG $HOME/strelka_config.txt
+
+ENV PYENSEMBL_CACHE_DIR /tool-cache/pyensembl
+ENV VAXRANK_REF_PEPTIDES_DIR /tool-cache/reference-peptides
+
+######## THESE ARE LAB-SPECIFIC BITS ########
+
 # need to link GATK
 COPY GenomeAnalysisTK.jar $HOME/GenomeAnalysisTK.jar
 RUN $PGV_BIN/gatk-register $HOME/GenomeAnalysisTK.jar
+
+# MuTect setup
+COPY mutect-1.1.7.jar $HOME/
+ENV MUTECT $HOME/mutect-1.1.7.jar
+
+# NetMHC setup
+ARG MHCBUNDLE_PASS
+RUN git clone https://mhcbundle:$MHCBUNDLE_PASS@github.com/openvax/netmhc-bundle.git && mkdir tmp
+ENV NETMHC_BUNDLE_TMPDIR $HOME/tmp
+ENV NETMHC_BUNDLE_HOME $HOME/netmhc-bundle
+ENV PATH $PATH:$NETMHC_BUNDLE_HOME/bin
+ENV KERAS_BACKEND tensorflow
 
 ENTRYPOINT ["./run.sh"]

--- a/docker/base/run.sh
+++ b/docker/base/run.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
+# Usage:
+# - config.json file describing Snakemake pipeline inputs, relative to Docker volume paths
+# - set of Snakemake targets
+
 SNAKEFILE=/pipeline/Snakefile
-CONFIGFILE=/inputs/config.json
-TARGETS=$@
+CONFIGFILE=$1
+TARGETS="${@:2}"
 
 snakemake \
 -s $SNAKEFILE \
---cores=2 \
+--cores=22 \
 --resources mem_mb=100000 \
 --configfile $CONFIGFILE \
 --config workdir=/outputs \
--np \
+-p \
 $TARGETS

--- a/docker/base/strelka_config.txt
+++ b/docker/base/strelka_config.txt
@@ -1,0 +1,21 @@
+[user]
+isSkipDepthFilters = 1
+maxInputDepth = 10000
+depthFilterMultiple = 3.0
+snvMaxFilteredBasecallFrac = 0.4
+snvMaxSpanningDeletionFrac = 0.75
+indelMaxRefRepeat = 8
+indelMaxWindowFilteredBasecallFrac = 0.3
+indelMaxIntHpolLength = 14
+ssnvPrior = 0.000001
+sindelPrior = 0.000001
+ssnvNoise = 0.0000005
+sindelNoise = 0.0000001
+ssnvNoiseStrandBiasFrac = 0.5
+minTier1Mapq = 40
+minTier2Mapq = 5
+ssnvQuality_LowerBound = 15
+sindelQuality_LowerBound = 30
+isWriteRealignedBam = 0
+binSize = 25000000
+extraStrelkaArguments = --eland-compatibility

--- a/snakemake/notes.txt
+++ b/snakemake/notes.txt
@@ -98,3 +98,14 @@ dbsnp.vcf.idx
 transcripts.gtf
 
 Also copy strelka_config.txt to /home/julia/bin/bin.
+
+----------
+
+A pipeline user outside Docker needs to go through the above setup, and also have the following environment variables set:
+- STRELKA_BIN: directory of Strelka installation, must contain configureStrelkaWorkflow.pl
+- STRELKA_CONFIG: path to Strelka config file
+- MUTECT: path to MuTect (v1) jar file
+- JAVA7_BIN: path to directory containing the java 7 executable
+
+Must also set PYENSEMBL_CACHE_DIR, and have it be writeable (see "pyensembl" rule in special_sauce.rules)
+Same for VAXRANK_REF_PEPTIDES_DIR.

--- a/snakemake/special_sauce.rules
+++ b/snakemake/special_sauce.rules
@@ -2,12 +2,11 @@
 This contains rules for our own data processing libraries.
 """
 
-# TODO(julia): add a rule for setting up Pyensembl cache, for now assuming it exists;
-# will need to do something like
-# export PYENSEMBL_CACHE_DIR='/biokepi/workdir/pyensembl-cache'
-# pyensembl install --release 75 --species "homo sapiens"
-# touch /biokepi/workdir/pyensembl-cache/b37decoy.cached
-# (add this last one as input to the vaxrank rule later)
+rule pyensembl:
+  output:
+    touch("$PYENSEMBL_CACHE_DIR/homo_sapiens_75.cached")
+  shell:
+    "pyensembl install --release 75 --species 'homo sapiens'"
 
 def _get_vaxrank_input_vcfs(wildcards):
     vcf_types = wildcards.vcf_types.split("-")
@@ -17,7 +16,8 @@ rule vaxrank:
   input:
     vcfs = _get_vaxrank_input_vcfs,
     rna = "{prefix}/rna_final_sorted.bam",
-    rna_index = "{prefix}/rna_final_sorted.bam.bai"
+    rna_index = "{prefix}/rna_final_sorted.bam.bai",
+    pyensembl_cache = "$PYENSEMBL_CACHE_DIR/homo_sapiens_75.cached"
   output:
     ascii_report = "{prefix}/vaccine-peptide-report-{vcf_types}.txt",
     json_file = "{prefix}/vaccine-peptide-report-{vcf_types}.json",
@@ -35,9 +35,9 @@ rule vaxrank:
     min_alt_rna_reads = 2,
     mhc_epitope_lengths = "8-11"
   benchmark:
-    "{prefix}/vaxrank_benchmark.txt"
+    "{prefix}/vaxrank-{vcf_types}-benchmark.txt"
   log:
-    "{prefix}/vaxrank.log"
+    "{prefix}/vaxrank-{vcf_types}.log"
   run:
     vcf_input_str = ""
     for vcf in input.vcfs:

--- a/snakemake/variant_calling.rules
+++ b/snakemake/variant_calling.rules
@@ -10,9 +10,7 @@ rule mutect_per_chr:
   params:
     reference = config["reference"]["genome"],
     cosmic = config["reference"]["cosmic"],
-    dbsnp = config["reference"]["dbsnp"],
-    java = "/home/julia/miniconda3/envs/java17/bin/java",
-    mutect_jar = "/biokepi/workdir/toolkit/mutect-1.1.7.jar"
+    dbsnp = config["reference"]["dbsnp"]
   benchmark:
     "{prefix}/mutect_{chr}_benchmark.txt"
   log:
@@ -20,7 +18,7 @@ rule mutect_per_chr:
   resources:
     mem_mb = 2000
   shell:
-    "{params.java} -Xmx2g -jar {params.mutect_jar} "
+    "$JAVA7_BIN/java -Xmx2g -jar $MUTECT "
     "--analysis_type MuTect "
     "--reference_sequence {params.reference} "
     "--cosmic {params.cosmic} "
@@ -77,6 +75,10 @@ rule mutect2:
 
 # TODO(julia): the logs here print to stdout still, need to figure out what the logs are coming from
 # and print to the logfile instead
+#
+# If not running in a Docker image, user must have these environment variables set:
+# - STRELKA_BIN: directory of Strelka installation, must contain configureStrelkaWorkflow.pl
+# - STRELKA_CONFIG: path to Strelka config file
 rule strelka:
   input:
     normal = "{prefix}/normal_aligned_coordinate_sorted_dups_indelreal_bqsr.bam",
@@ -86,8 +88,6 @@ rule strelka:
     "{prefix}/strelka_output/results/passed.somatic.indels.vcf"
   params:
     reference = config["reference"]["genome"],
-    strelka_bin = config["tools"]["strelka"]["bin"],
-    strelka_config = config["tools"]["strelka"]["config"],
     output_dir = "{prefix}/strelka_output"
   benchmark:
     "{prefix}/strelka_benchmark.txt"
@@ -96,15 +96,15 @@ rule strelka:
   threads: 20
   shell:
     "rm -rf {params.output_dir}; "
-    "{params.strelka_bin}/configureStrelkaWorkflow.pl "
+    "$STRELKA_BIN/configureStrelkaWorkflow.pl "
     "--normal {input.normal} "
     "--tumor {input.tumor} "
     "--ref {params.reference} "
-    "--config {params.strelka_config} "
-    "--output-dir {params.output_dir}; "
+    "--config $STRELKA_CONFIG "
+    "--output-dir {params.output_dir} &> {log}; "
     "cd {params.output_dir}; "
     "make -j {threads} "
-    "2> {log}"
+    ">> {log} 2>&1"
 
 rule strelka_combine:
   input:


### PR DESCRIPTION
Including but not limited to:
    - Adding support for netmhc-bundle addition, provided user has GH password
    - Updating conda dependencies
    - Decreasing image size: cleaning up after apt-get, conda installs
    - Fixing Vaxrank log/benchmark rule files, was previously broken
    - Updating tool cache locations in the pipeline, for pyensembl and vaxrank
    - Updating non-Docker notes