### PR TITLE
More pipeline changes

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -116,32 +116,42 @@ RUN pip install --ignore-installed vaxrank==0.7.12
 # needed for vaxrank reports to be reasonably formatted, otherwise kerning is off
 RUN curl https://pastebin.com/raw/AmfYN3er > $HOME/.fonts.conf
 
-# Copy the current directory contents into the container
-ADD . $HOME
-
-# set up Strelka config
-COPY strelka_config.txt $HOME/
-ENV STRELKA_CONFIG $HOME/strelka_config.txt
-
-ENV PYENSEMBL_CACHE_DIR /tool-cache/pyensembl
-ENV VAXRANK_REF_PEPTIDES_DIR /tool-cache/reference-peptides
-
 ######## THESE ARE LAB-SPECIFIC BITS ########
-
-# need to link GATK
-COPY GenomeAnalysisTK.jar $HOME/GenomeAnalysisTK.jar
-RUN $PGV_BIN/gatk-register $HOME/GenomeAnalysisTK.jar
-
-# MuTect setup
-COPY mutect-1.1.7.jar $HOME/
-ENV MUTECT $HOME/mutect-1.1.7.jar
 
 # NetMHC setup
 ARG MHCBUNDLE_PASS
-RUN git clone https://mhcbundle:$MHCBUNDLE_PASS@github.com/openvax/netmhc-bundle.git && mkdir tmp
+RUN git clone https://mhcbundle:$MHCBUNDLE_PASS@github.com/openvax/netmhc-bundle.git && \
+    rm -rf netmhc-bundle/netMHCIIpan-3.0 && \
+    rm -rf netmhc-bundle/netMHCIIpan-3.1 && \
+    rm -rf netmhc-bundle/netMHC-3.4 && \
+    rm -rf netmhc-bundle/netMHCpan-2.8 && \
+    rm -rf netmhc-bundle/netMHCpan-4.0 && \
+    rm -rf netmhc-bundle/netMHCstab-1.0 && \
+    rm -rf netmhc-bundle/netchop-3.1 && \
+    mkdir tmp
 ENV NETMHC_BUNDLE_TMPDIR $HOME/tmp
 ENV NETMHC_BUNDLE_HOME $HOME/netmhc-bundle
 ENV PATH $PATH:$NETMHC_BUNDLE_HOME/bin
 ENV KERAS_BACKEND tensorflow
 
-ENTRYPOINT ["./run.sh"]
+ENV PYENSEMBL_CACHE_DIR /outputs/pyensembl-cache
+ENV VAXRANK_REF_PEPTIDES_DIR /outputs/reference-peptides
+
+######## SOME OF THESE ARE LAB-SPECIFIC BITS ########
+# Last in Dockerfile for efficiency reasons: "ADD . $HOME" and everything after it
+# gets rebuilt every time we change anything in this repository.
+
+# Copy the current directory contents into the container
+ADD . $HOME
+
+# snakemake logs get written here (hidden dir)
+RUN sudo chown -R $USER $HOME/.snakemake
+
+# need to link GATK
+RUN $PGV_BIN/gatk-register $HOME/docker/base/GenomeAnalysisTK.jar
+
+# Variant caller setup
+ENV MUTECT $HOME/docker/base/mutect-1.1.7.jar
+ENV STRELKA_CONFIG $HOME/docker/base/strelka_config.txt
+
+ENTRYPOINT ["python", "docker/base/run_snakemake.py"]

--- a/docker/base/run_snakemake.py
+++ b/docker/base/run_snakemake.py
@@ -1,0 +1,61 @@
+from __future__ import print_function, division, absolute_import
+from argparse import ArgumentParser
+import json
+import os
+import datetime
+
+import snakemake
+
+parser = ArgumentParser()
+parser.add_argument(
+    "--configfile",
+    default="",
+    help="Docker-relative Snakemake JSON config file path")
+parser.add_argument(
+    "--target",
+    action="append",
+    help="Snakemake target(s). For multiple targets, can specify --target t1 --target t2 ...")
+parser.add_argument(
+    "--snakefile",
+    default="snakemake/Snakefile",
+    help="Docker-relative path to Snakefile")
+parser.add_argument(
+    "--cores",
+    default=22,
+    type=int,
+    help="Number of CPU cores to use in this pipeline run")
+
+def compute_vaxrank_targets(config_file_path):
+    """
+    configfile: Docker-relative path to a JSON config file
+    """
+    with open(config_file_path) as configfile:
+        config = json.load(configfile)
+        output_dir = os.path.join(config["workdir"], config["input"]["id"])
+        targets = [
+            # TODO(julia): add mutect2 vaxrank report to this
+            os.path.join(output_dir, "vaccine-peptide-report-mutect-strelka.txt"),
+        ]
+        return targets
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    print(args)
+
+    # check target
+    targets = args.target
+    if targets is None:
+        targets = compute_vaxrank_targets(args.configfile)
+
+    start_time = datetime.datetime.now()
+    snakemake.snakemake(
+        args.snakefile,
+        cores=args.cores,
+        resources={'mem_mb': 160000},
+        configfile=args.configfile,
+        config={'num_threads': args.cores},
+        printshellcmds=True,
+        targets=targets,
+    )
+    end_time = datetime.datetime.now()
+    print("--- Pipeline running time: %s ---" % (str(end_time - start_time)))

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -72,8 +72,6 @@ include:
 
 SAMPLE_ID = config["input"]["id"]
 WORKDIR = os.path.join(config["workdir"], SAMPLE_ID)
-
-CHR = list(range(1, 23)) + ['X', 'Y', 'MT']
 SUPPORTED_FILETYPES = {".fastq.gz", ".fastq", ".bam"}
 
 # copy all fragments over to the sample-specific workdir, create if it doesn't exist

--- a/snakemake/common.rules
+++ b/snakemake/common.rules
@@ -1,3 +1,8 @@
+CHR = [str(x) for x in range(1, 23)] + ['X', 'Y', 'MT']
+
+# will default to false, if not present in config
+_PARALLEL_INDEL_REALIGNER = config.get("parallel_indel_realigner")
+
 # Common functions
 
 def _get_half_cores(_):
@@ -5,6 +10,9 @@ def _get_half_cores(_):
 
 def _get_all_cores(_):
   return int(config["num_threads"])
+
+def _get_intervals_str(wildcards):
+  return "--intervals %s" % wildcards.chr if wildcards.chr in CHR else ""
 
 rule zip_fastq:
   input:

--- a/snakemake/gatk.rules
+++ b/snakemake/gatk.rules
@@ -37,9 +37,11 @@ rule sambamba_index_bam:
   shell:
     "sambamba index -t {threads} {input} {output} 2> {log}"
 
-CHR = list(range(1, 23)) + ['X', 'Y', 'MT']
-
 # TODO(julia): figure out how to combine with RNA IndelRealigner rules, very similar
+
+# if this rule is triggered with "chr" mapping to a chromosome in the CHR list, it'll be run
+# for that chromosome alone. If "chr" matches any other string, IndelRealigner will run for all
+# chromosomes.
 rule dna_indel_realigner_target_creator_per_chr:
   input:
     expand("{{prefix}}/{type}_aligned_coordinate_sorted_dups.bam.bai", type=["normal", "tumor"]),
@@ -56,13 +58,19 @@ rule dna_indel_realigner_target_creator_per_chr:
     "{prefix}/dna_indel_realigner_target_creator_{chr}.log"
   resources:
     mem_mb = 20000
-  shell:
-    "gatk -Xmx20g -T RealignerTargetCreator -R {params.reference} "
-    "--intervals {wildcards.chr} "
-    "-I {input.normal} -I {input.tumor} -o {output} -nt {threads} "
-    "--filter_reads_with_N_cigar --filter_mismatching_base_and_quals --filter_bases_not_stored "
-    "2> {log}"
+  run:
+    intervals_str = _get_intervals_str(wildcards)
+    shell("""
+      gatk -Xmx20g -T RealignerTargetCreator -R {params.reference} \
+      %s \
+      -I {input.normal} -I {input.tumor} -o {output} -nt {threads} \
+      --filter_reads_with_N_cigar --filter_mismatching_base_and_quals --filter_bases_not_stored \
+      2> {log}
+    """ % intervals_str)
 
+# if this rule is triggered with "chr" mapping to a chromosome in the CHR list, it'll be run
+# for that chromosome alone. If "chr" matches any other string, IndelRealigner will run for all
+# chromosomes.
 rule dna_indel_realigner_per_chr:
   input:
     expand("{{prefix}}/{type}_aligned_coordinate_sorted_dups.bam.bai", type=["normal", "tumor"]),
@@ -81,27 +89,49 @@ rule dna_indel_realigner_per_chr:
   resources:
     mem_mb = 20000
   # IndelRealigner writes the output to this directory; need to move the files manually after
-  shell:
-    "gatk -Xmx20g -T IndelRealigner -compress 0 -R {params.reference} "
-    "-I {input.normal} -I {input.tumor} "
-    "-targetIntervals {input.intervals} --intervals {wildcards.chr} "
-    "--filter_reads_with_N_cigar --filter_mismatching_base_and_quals --filter_bases_not_stored "
-    "--nWayOut _indelreal_chr_{wildcards.chr}.bam "
-    "2> {log} && "
-    "mv {{normal,tumor}}_aligned_coordinate_sorted_dups_indelreal_chr_{wildcards.chr}.bam "
-    "{wildcards.prefix} && "
-    "mv {{normal,tumor}}_aligned_coordinate_sorted_dups_indelreal_chr_{wildcards.chr}.bai "
-    "{wildcards.prefix}"
+  run:
+    intervals_str = _get_intervals_str(wildcards)
+    shell("""
+      gatk -Xmx20g -T IndelRealigner -compress 0 -R {params.reference} \
+      -I {input.normal} -I {input.tumor} \
+      -targetIntervals {input.intervals} %s \
+      --filter_reads_with_N_cigar --filter_mismatching_base_and_quals --filter_bases_not_stored \
+      --nWayOut _indelreal_chr_{wildcards.chr}.bam \
+      2> {log} && \
+      mv {{normal,tumor}}_aligned_coordinate_sorted_dups_indelreal_chr_{wildcards.chr}.bam \
+      {wildcards.prefix} && \
+      mv {{normal,tumor}}_aligned_coordinate_sorted_dups_indelreal_chr_{wildcards.chr}.bai \
+      {wildcards.prefix}
+    """ % intervals_str)
 
-rule dna_indel_realigner_merge:
+def _get_dna_indel_realigner_input(wildcards):
+  if _PARALLEL_INDEL_REALIGNER:
+    return ["%s_aligned_coordinate_sorted_dups_indelreal_chr_%s.bam" % (
+        wildcards.prefix, chromosome) for chromosome in CHR]
+  else:
+    return "%s_aligned_coordinate_sorted_dups_indelreal_chr_ALL.bam" % wildcards.prefix
+
+def _get_bai_from_bam_name(bam_input):
+  return 
+
+rule dna_indel_realigner:
   input:
-    expand("{{prefix}}_aligned_coordinate_sorted_dups_indelreal_chr_{chr}.bam", chr=CHR)
+    bam = _get_dna_indel_realigner_input
   output:
-    "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam"
+    bam = "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam"
   benchmark:
-    "{prefix}/dna_indel_realigner_merge_benchmark.txt"
-  shell:
-    "sambamba merge {output} {input}"
+    "{prefix}_indel_realigner_benchmark.txt"
+  log:
+    "{prefix}_indel_realigner.log"
+  run:
+    if _PARALLEL_INDEL_REALIGNER:
+      shell("sambamba merge {output.bam} {input.bam}")
+    else:
+      shell("mv {input.bam} {output.bam}")
+      input_bai = input.bam.replace(".bam", ".bai")
+      output_bai = output.bam.replace(".bam", ".bai")
+      # also need to rename the .bai from the .bam
+      shell("mv %s %s" % (input_bai, output_bai))
 
 rule base_recalibrator:
   input:

--- a/snakemake/idh1_config.json
+++ b/snakemake/idh1_config.json
@@ -43,5 +43,6 @@
         }
     },
     "run_mutect2": true,
-    "num_threads": 20
+    "num_threads": 20,
+    "parallel_indel_realigner": true
 }

--- a/snakemake/rna.rules
+++ b/snakemake/rna.rules
@@ -141,29 +141,34 @@ rule sort_rna_bam:
     "{input} "
     "2> {log}"
 
-CHR = list(range(1, 23)) + ['X', 'Y', 'MT']
+# run indel realignment on the reads without Ns
 
-# run per-chromosome indel realignment on the reads without Ns
+# if this rule is triggered with "chr" mapping to a chromosome in the CHR list, it'll be run
+# for that chromosome alone. If "chr" matches any other string, IndelRealigner will run for all
+# chromosomes.
 rule rna_indel_realigner_target_creator_per_chr:
   input:
     "{prefix}/rna_aligned_coordinate_sorted_dups_cigar_0-9MIDSHPX_filtered_sorted.bam"
   output:
     "{prefix}/rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal_{chr}.intervals"
+  threads: _get_half_cores
   params:
     reference = config["reference"]["genome"]
   benchmark:
     "{prefix}/rna_indel_realigner_target_creator_{chr}_benchmark.txt"
   log:
     "{prefix}/rna_indel_realigner_target_creator_{chr}.log"
-  threads: _get_half_cores
   resources:
     mem_mb = 20000
-  shell:
-    "gatk -Xmx20g -T RealignerTargetCreator -R {params.reference} "
-    "--intervals {wildcards.chr} "
-    "-I {input} -o {output} -nt {threads} "
-    "--filter_mismatching_base_and_quals --filter_bases_not_stored "
-    "2> {log}"
+  run:
+    intervals_str = _get_intervals_str(wildcards)
+    shell("""
+      gatk -Xmx20g -T RealignerTargetCreator -R {params.reference} \
+      %s \
+      -I {input} -o {output} -nt {threads} \
+      --filter_mismatching_base_and_quals --filter_bases_not_stored \
+      2> {log}
+    """ % intervals_str)
 
 rule rna_indel_realigner_per_chr:
   input:
@@ -179,21 +184,36 @@ rule rna_indel_realigner_per_chr:
     "{prefix}/rna_indel_realigner_{chr}.log"
   resources:
     mem_mb = 20000
-  shell:
-    "gatk -Xmx20g -T IndelRealigner -compress 0 -R {params.reference} -I {input.bam} "
-    "-targetIntervals {input.intervals} --intervals {wildcards.chr} -o {output} "
-    "--filter_mismatching_base_and_quals --filter_bases_not_stored "
-    "2> {log}"
+  run:
+    intervals_str = _get_intervals_str(wildcards)
+    shell("""
+      gatk -Xmx20g -T IndelRealigner -compress 0 -R {params.reference} -I {input.bam} \
+      -targetIntervals {input.intervals} %s -o {output} \
+      --filter_mismatching_base_and_quals --filter_bases_not_stored \
+      2> {log}
+    """ % intervals_str)
 
-rule rna_indel_realigner_merge:
+def _get_rna_indel_realigner_input(wildcards):
+  if _PARALLEL_INDEL_REALIGNER:
+    return ["%s/rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal_chr_%s.bam" % (
+      wildcards.prefix, chromosome) for chromosome in CHR]
+  else:
+    return "%s/rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal_chr_ALL.bam" % wildcards.prefix
+
+rule rna_indel_realigner:
   input:
-    expand("{{prefix}}/rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal_{chr}.bam", chr=CHR)
+    _get_rna_indel_realigner_input
   output:
     "{prefix}/rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal.bam"
   benchmark:
-    "{prefix}/rna_indel_realigner_merge_benchmark.txt"
-  shell:
-    "sambamba merge {output} {input}"
+    "{prefix}/rna_indel_realigner_benchmark.txt"
+  log:
+    "{prefix}/rna_indel_realigner.log"
+  run:
+    if _PARALLEL_INDEL_REALIGNER:
+      shell("sambamba merge {output} {input}")
+    else:
+      shell("mv {input} {output}")
 
 rule merge_all_rna:
   input:


### PR DESCRIPTION
- Adding a Python entrypoint to the Dockerfile
- By default, the pipeline will run Vaxrank with MuTect and Strelka VCFs
- Making indel realigner parallelization optional; defaulting to not parallel
- Decreasing image size: getting rid of unneeded MHC predictor binaries
- Fixing some pipeline/filenaming typos