### PR TITLE
Update to use modern tooling

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Build with: docker build -f docker/Dockerfile .
 
-FROM --platform=linux/amd64 ubuntu:16.04
+FROM --platform=linux/amd64 ubuntu:22.04
 
 MAINTAINER Julia Kodysh <julia326@gmail.com>
 
@@ -18,14 +18,13 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
         libx11-dev \
         libbz2-dev \
         libcurl4-openssl-dev \
-        libgnutls-dev \
+        libgnutls28-dev \
         libssl-dev \
         make \
         perl \
         pkg-config \
         python-tk \
         python2.7-dev \
-        python3.5-dev \
         rsync \
         sudo \
         tar \
@@ -38,12 +37,12 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
     rm -rf /var/lib/apt/lists/*
 
 # install wkhtmltopdf from source, this version comes with patched QT necessary for PDF gen
-RUN cd /tmp && \
-    wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz && \
-    tar xvfJ wkhtmltox-0.12.4_linux-generic-amd64.tar.xz && \
-    cd /tmp/wkhtmltox/bin && sudo chown root:root wkhtmltopdf && \
-    sudo cp /tmp/wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf && \
-    rm -rf /tmp/*
+# RUN cd /tmp && \
+#    wget https://github.com/wkhtmltopdf/wkhtmltopdf/archive/refs/tags/0.12.6.tar.gz && \
+#    tar xvzf 0.12.6.tar.gz && \
+#    cd /tmp/wkhtmltox/bin && sudo chown root:root wkhtmltopdf && \
+#    sudo cp /tmp/wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf && \
+#    rm -rf /tmp/*
 
 RUN useradd --create-home --home-dir /home/user --shell /bin/bash -G sudo user && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
@@ -66,17 +65,17 @@ ENV PERL5LIB /usr/local/lib
 
 # Install Strelka
 # Original address for Strelka: ftp://strelka:%27%27@ftp.illumina.com/v1-branch/v1.0.14/strelka_workflow-1.0.14.tar.gz
-RUN mkdir $HOME/strelka && \
-    cd /tmp && wget https://github.com/openvax/neoantigen-vaccine-pipeline/releases/download/0.3.0/strelka_workflow-1.0.14.tar.gz && \
-    tar xvfz strelka_workflow-1.0.14.tar.gz && \
-    cd strelka_workflow-1.0.14 && \
-    ./configure prefix=$HOME/strelka && \
-    make && \
-    chmod -R a+rx ./* && \
-    make install && \
-    rm -rf /tmp/*
+# RUN mkdir $HOME/strelka && \
+#     cd /tmp && wget https://github.com/openvax/neoantigen-vaccine-pipeline/releases/download/0.3.0/strelka_workflow-1.0.14.tar.gz && \
+#     tar xvfz strelka_workflow-1.0.14.tar.gz && \
+#     cd strelka_workflow-1.0.14 && \
+#     ./configure prefix=$HOME/strelka && \
+#     make && \
+#     chmod -R a+rx ./* && \
+#     make install && \
+#     rm -rf /tmp/*
 
-ENV STRELKA_BIN $HOME/strelka/bin
+# ENV STRELKA_BIN $HOME/strelka/bin
 
 # Install Miniconda
 RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && \
@@ -95,29 +94,48 @@ RUN conda config --add channels r && \
     conda config --add channels conda-forge && \
     conda config --add channels bioconda && \
     conda create -n pgv \
-    setuptools==57.4.0 \
+    setuptools \
     python=3.6 \
     bedtools \
     bwa==0.7.17 \
     cython \
     fastqc \
     gatk==3.7 \
-    java-jdk==8.0.92 \
+    java-jdk==8.0.112 \
     picard==2.18.5 \
-    pip==19.0.3 \
-    sambamba==0.6.6 \
-    samtools==1.8 \
+    pip \
+    sambamba \
+    samtools \
     star==2.6.0c \
     vcftools==0.1.15 \
     && conda clean --all -y
 
-# We also setup a newer environment with mhcflurry and an updated vaxrank.
+# bwa==0.7.17 gatk==3.7 java-jdk==8.0.92 picard==2.18.5 sambamba
+
+# We also setup a newer environment with mhcflurry.
 RUN conda config --add channels r && \
     conda config --add channels defaults && \
     conda config --add channels conda-forge && \
     conda config --add channels bioconda && \
     conda create -n mhcflurry \
-    python=3.7 numpy pandas pip
+    python=3.7 numpy pandas pip \
+    && conda clean --all -y
+
+# And an older one with Python 2.7 so that Strelka can run.
+RUN conda config --add channels r && \
+    conda config --add channels defaults && \
+    conda config --add channels conda-forge && \
+    conda config --add channels bioconda && \
+    conda create -n mhcflurry \
+    python==2.7 \
+    strelka==2.9.10 \
+    && conda clean --all -y
+
+# MuTect needs Java 1.7, while GATK and other things need Java 1.8.
+# Dealing with this by setting up a separate Conda environment, specifically for Java 7
+RUN conda create -n java7 \
+    java-jdk==7.0.91 \
+    && conda clean --all -y
 
 ENV MHCFLURRY_BIN /home/user/miniconda/envs/mhcflurry/bin
 RUN $MHCFLURRY_BIN/pip install 'tensorflow-cpu<=2.3.0' mhcflurry vaxrank
@@ -126,13 +144,8 @@ RUN $MHCFLURRY_BIN/mhcflurry-downloads fetch
 # Test MHCflurry
 RUN $MHCFLURRY_BIN/mhcflurry-predict --alleles HLA-A0201 --peptides SIINFEKL
 
-
 # most of the tools we're using are in the pgv environment; adding to PATH for convenience
 ENV PATH $PGV_BIN:$PATH
-
-# MuTect needs Java 1.7, while GATK and other things need Java 1.8.
-# Dealing with this by setting up a separate Conda environment, specifically for Java 7
-RUN conda create -n java7 java-jdk==7.0.91 && conda clean --all -y
 
 # Set up MuTect 1.1.7
 RUN wget -O $HOME/mutect-1.1.7.jar http://storage.googleapis.com/common-files/tools/mutect-1.1.7.jar

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,8 +75,6 @@ ENV PERL5LIB /usr/local/lib
 #     make install && \
 #     rm -rf /tmp/*
 
-# ENV STRELKA_BIN $HOME/strelka/bin
-
 # Install Miniconda
 RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && \
     bash miniconda.sh -b -p $HOME/miniconda
@@ -110,24 +108,22 @@ RUN conda config --add channels r && \
     vcftools==0.1.15 \
     && conda clean --all -y
 
-# bwa==0.7.17 gatk==3.7 java-jdk==8.0.92 picard==2.18.5 sambamba
-
 # We also setup a newer environment with mhcflurry.
-RUN conda config --add channels r && \
-    conda config --add channels defaults && \
-    conda config --add channels conda-forge && \
-    conda config --add channels bioconda && \
-    conda create -n mhcflurry \
-    python=3.7 numpy pandas pip \
-    && conda clean --all -y
+#RUN conda config --add channels r && \
+#    conda config --add channels defaults && \
+#    conda config --add channels conda-forge && \
+#    conda config --add channels bioconda && \
+#    conda create -n mhcflurry \
+#    python=3.7 numpy pandas pip \
+#    && conda clean --all -y
 
 # And an older one with Python 2.7 so that Strelka can run.
 RUN conda config --add channels r && \
     conda config --add channels defaults && \
     conda config --add channels conda-forge && \
     conda config --add channels bioconda && \
-    conda create -n mhcflurry \
-    python==2.7 \
+    conda create -n strelka \
+    python=2.7 \
     strelka==2.9.10 \
     && conda clean --all -y
 
@@ -137,12 +133,12 @@ RUN conda create -n java7 \
     java-jdk==7.0.91 \
     && conda clean --all -y
 
-ENV MHCFLURRY_BIN /home/user/miniconda/envs/mhcflurry/bin
-RUN $MHCFLURRY_BIN/pip install 'tensorflow-cpu<=2.3.0' mhcflurry vaxrank
-RUN $MHCFLURRY_BIN/mhcflurry-downloads fetch
+#ENV MHCFLURRY_BIN /home/user/miniconda/envs/mhcflurry/bin
+#RUN $MHCFLURRY_BIN/pip install 'tensorflow-cpu<=2.3.0' mhcflurry vaxrank
+#RUN $MHCFLURRY_BIN/mhcflurry-downloads fetch
 
 # Test MHCflurry
-RUN $MHCFLURRY_BIN/mhcflurry-predict --alleles HLA-A0201 --peptides SIINFEKL
+#RUN $MHCFLURRY_BIN/mhcflurry-predict --alleles HLA-A0201 --peptides SIINFEKL
 
 # most of the tools we're using are in the pgv environment; adding to PATH for convenience
 ENV PATH $PGV_BIN:$PATH
@@ -173,6 +169,7 @@ COPY . $HOME
 
 # Strelka setup
 ENV STRELKA_CONFIG $HOME/pipeline/strelka_config.txt
+ENV STRELKA_BIN $HOME/miniconda/envs/strelka/bin
 
 # Python scripts setup, for things that are too small/simple to be their own modules
 ENV SCRIPTS $HOME/pipeline/scripts

--- a/pipeline/special_sauce.rules
+++ b/pipeline/special_sauce.rules
@@ -32,7 +32,7 @@ if "mhc_alleles" in config["input"] and _rna_exists():
         if wildcards.vcf_types != "-".join(config["variant_callers"]):
             raise ValueError("Vaccine peptide report output filenames must match variant callers "
                 "specified in config: %s" % config["variant_callers"])
-    
+
     rule vaxrank:
       input:
         vcfs = _get_vaxrank_input_vcfs,
@@ -41,7 +41,8 @@ if "mhc_alleles" in config["input"] and _rna_exists():
       output:
         ascii_report = join(WORKDIR, "vaccine-peptide-report_{mhc_predictor}_{vcf_types}.txt"),
         json_file = join(WORKDIR, "vaccine-peptide-report_{mhc_predictor}_{vcf_types}.json"),
-        pdf_report = join(WORKDIR, "vaccine-peptide-report_{mhc_predictor}_{vcf_types}.pdf"),
+	# commenting this out for now: will need to figure out wkhtmltopdf install in Docker image
+        #pdf_report = join(WORKDIR, "vaccine-peptide-report_{mhc_predictor}_{vcf_types}.pdf"),
         all_passing_variants = join(WORKDIR, "all-passing-variants_{mhc_predictor}_{vcf_types}.csv")
       params:
         # excel report is a param because if there are no vaccine peptides, this output won't exist
@@ -69,7 +70,6 @@ if "mhc_alleles" in config["input"] and _rna_exists():
             --mhc-predictor {wildcards.mhc_predictor} \
             --mhc-alleles %s \
             --output-ascii-report {output.ascii_report} \
-            --output-pdf-report {output.pdf_report} \
             --output-xlsx-report {params.xlsx_report} \
             --output-json-file {output.json_file} \
             --output-passing-variants-csv {output.all_passing_variants} \

--- a/pipeline/variant_calling.rules
+++ b/pipeline/variant_calling.rules
@@ -108,7 +108,7 @@ rule strelka:
     normal = join(WORKDIR, "normal_aligned_coordinate_sorted_dups_indelreal_bqsr.bam"),
     tumor = join(WORKDIR, "tumor_aligned_coordinate_sorted_dups_indelreal_bqsr.bam")
   output:
-    expand(join(WORKDIR, "strelka_output/results/passed.somatic.{type}.vcf"),
+    expand(join(WORKDIR, "strelka_output/results/variants/somatic.{type}.vcf.gz"),
       type=['snvs', 'indels'])
   params:
     output_dir = join(WORKDIR, "strelka_output"),
@@ -120,20 +120,20 @@ rule strelka:
   threads: _get_all_cores
   shell:
     "rm -rf {params.output_dir}; "
-    "$STRELKA_BIN/configureStrelkaWorkflow.pl "
+    "$STRELKA_BIN/configureStrelkaSomaticWorkflow.py "
     "--normal {input.normal} "
     "--tumor {input.tumor} "
     "--ref {params.reference} "
     "--config $STRELKA_CONFIG "
-    "--output-dir {params.output_dir} &> {log}; "
+    "--runDir {params.output_dir} &> {log}; "
     "cd {params.output_dir}; "
-    "make -j {threads} "
+    "./runWorkflow.py -m local -j {threads} "
     ">> {log} 2>&1"
 
 rule strelka_combine:
   input:
-    snvs = join(WORKDIR, "strelka_output/results/passed.somatic.snvs.vcf"),
-    indels = join(WORKDIR, "strelka_output/results/passed.somatic.indels.vcf")
+    snvs = join(WORKDIR, "strelka_output/results/variants/somatic.snvs.vcf.gz"),
+    indels = join(WORKDIR, "strelka_output/results/variants/somatic.indels.vcf.gz")
   output:
     join(WORKDIR, "strelka.vcf")
   params:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 cython
-isovar
-mhctools
+isovar==1.3.0
+mhctools==1.8.1
 psutil
-pyensembl
+pyensembl==2.2.4
 pyyaml
 snakemake==5.4.4
-varcode
-vaxrank
+varcode==1.1.0
+vaxrank==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 cython
-isovar==0.9.0
-mhctools>=1.8.1
+isovar
+mhctools
 psutil
-pyensembl==1.7.3
+pyensembl
 pyyaml
 snakemake==5.4.4
-varcode==0.8.0
-vaxrank==1.0.0
+varcode
+vaxrank

--- a/run_snakemake.py
+++ b/run_snakemake.py
@@ -200,7 +200,8 @@ def default_vaxrank_targets(config):
     path_without_ext = join(
         get_output_dir(config),
         "vaccine-peptide-report_%s_%s" % (mhc_predictor, vcfs))
-    return ['%s.%s' % (path_without_ext, ext) for ext in ('txt', 'json', 'pdf')]
+    # removed 'pdf' from this list until we install wkhtmltopdf in Docker image
+    return ['%s.%s' % (path_without_ext, ext) for ext in ('txt', 'json')]
 
 
 def somatic_vcf_targets(config):


### PR DESCRIPTION
Details:
- Base Ubuntu image 22.04
- Strelka 1 -> Strelka 2, installed with conda
- OpenVax Python stack update: vaxrank 1.0.0 -> 1.4.0 (also necessitated bumping other tools in the stack)

Removing a few things for now:
- wkhtmltopdf install: not urgent to fix, but prevents Vaxrank having PDF outputs
- commenting out mhcflurry-related Docker setup for image build speed