### PR TITLE
Making most output files Snakemake-temp, so that the pipeline cleans up after itself as it goes

### DIFF
--- a/pipeline/alignment.rules
+++ b/pipeline/alignment.rules
@@ -48,7 +48,7 @@ rule bwa_mem_single_end:
     r = join(WORKDIR, "{prefix}.fastq.gz"),
     done = config["reference"]["genome"] + ".done"
   output:
-    join(WORKDIR, "{prefix}_aligned.sam")
+    temp(join(WORKDIR, "{prefix}_aligned.sam"))
   params:
     rg = _get_read_group_header,
     reference = config["reference"]["genome"]
@@ -70,7 +70,7 @@ rule bwa_mem_paired_end:
     r2 = join(WORKDIR, "{prefix}_R2.fastq.gz"),
     done = config["reference"]["genome"] + ".done"
   output:
-    join(WORKDIR, "{prefix}_aligned.sam")
+    temp(join(WORKDIR, "{prefix}_aligned.sam"))
   params:
     rg = _get_read_group_header,
     reference = config["reference"]["genome"]
@@ -90,7 +90,8 @@ rule convert_alignment_to_sorted_bam:
   input:
     join(WORKDIR, "{prefix}_aligned.sam")
   output:
-    join(WORKDIR, "{prefix}_aligned_coordinate_sorted.bam")
+    bam = temp(join(WORKDIR, "{prefix}_aligned_coordinate_sorted.bam")),
+    tmpdir = temp(directory(join(WORKDIR, "{prefix}_tmp")))
   params:
     mem_gb = _mem_gb_for_ram_hungry_jobs(),
     tmpdir = join(WORKDIR, "{prefix}_tmp")
@@ -103,14 +104,14 @@ rule convert_alignment_to_sorted_bam:
   shell:
     "TMPDIR={params.tmpdir} "
     "picard -Xmx{params.mem_gb}g -Djava.io.tmpdir={params.tmpdir} "
-    "SortSam INPUT={input} OUTPUT={output} SORT_ORDER=coordinate 2> {log}"
+    "SortSam INPUT={input} OUTPUT={output.bam} SORT_ORDER=coordinate 2> {log}"
 
 rule merge_normal_aligned_fragments:
   input:
     expand(join(WORKDIR, "normal_{fragment_id}_aligned_coordinate_sorted.bam"),
       fragment_id=_get_fragment_ids("normal"))
   output:
-    join(WORKDIR, "normal_merged_aligned_coordinate_sorted.bam")
+    temp(join(WORKDIR, "normal_merged_aligned_coordinate_sorted.bam"))
   threads: _get_half_cores
   run:
     if len(input) > 1:
@@ -123,7 +124,7 @@ rule merge_tumor_aligned_fragments:
     expand(join(WORKDIR, "tumor_{fragment_id}_aligned_coordinate_sorted.bam"),
       fragment_id=_get_fragment_ids("tumor"))
   output:
-    join(WORKDIR, "tumor_merged_aligned_coordinate_sorted.bam")
+    temp(join(WORKDIR, "tumor_merged_aligned_coordinate_sorted.bam"))
   threads: _get_half_cores
   run:
     if len(input) > 1:

--- a/pipeline/common.rules
+++ b/pipeline/common.rules
@@ -14,6 +14,7 @@
 
 # This file contains pipeline constants and a few functions.
 
+import glob
 from os.path import join, dirname, splitext
 
 SAMPLE_ID = config["input"]["id"]
@@ -68,6 +69,9 @@ def _get_fragment_ids(input_type):
     for fragment in config["input"][input_type]:
       fragment_ids.append(fragment["fragment_id"])
   return fragment_ids
+
+def _get_all_fastq_files(_):
+    return glob.glob("%s/*.fastq.gz" % WORKDIR)
 
 def sequence_dict_output():
   root, ext = splitext(config["reference"]["genome"])

--- a/pipeline/gatk.rules
+++ b/pipeline/gatk.rules
@@ -22,7 +22,8 @@ rule mark_dups:
   input:
     join(WORKDIR, "{prefix}_merged_aligned_coordinate_sorted.bam")
   output:
-    bam = join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups.bam"),
+    bam = temp(join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups.bam")),
+    tmpdir = temp(directory(join(WORKDIR, "{prefix}_tmp"))),
     metrics_file = join(WORKDIR, "{prefix}_markdups_metrics.txt")
   params:
     mem_gb = _mem_gb_for_ram_hungry_jobs(),
@@ -48,7 +49,7 @@ rule sambamba_index_bam:
   input:
     join(WORKDIR, "{prefix}.bam")
   output:
-    join(WORKDIR, "{prefix}.bam.bai")
+    temp(join(WORKDIR, "{prefix}.bam.bai"))
   threads: _get_half_cores
   benchmark:
     join(BENCHMARKDIR, "{prefix}_sambamba_index.txt")
@@ -151,8 +152,8 @@ if _PARALLEL_INDEL_REALIGNER:
         join(WORKDIR, "{{prefix}}_aligned_coordinate_sorted_dups_indelreal_chr_{chr}.bai"),
         chr=config["contigs"])
     output:
-      bam = join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam"),
-      bai = join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam.bai")
+      bam = temp(join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam")),
+      bai = temp(join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam.bai"))
     benchmark:
       join(BENCHMARKDIR, "{prefix}_indel_realigner.txt")
     log:
@@ -166,8 +167,8 @@ else:
       bam = join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal_chr_ALL.bam"),
       bai = join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal_chr_ALL.bai")
     output:
-      bam = join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam"),
-      bai = join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam.bai")
+      bam = temp(join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam")),
+      bai = temp(join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam.bai"))
     benchmark:
       join(BENCHMARKDIR, "{prefix}_indel_realigner.txt")
     log:
@@ -181,7 +182,7 @@ rule base_recalibrator:
     bam = join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam"),
     bai = join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam.bai")
   output:
-    join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal_bqsr.table")
+    temp(join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal_bqsr.table"))
   params:
     mem_gb = _mem_gb_for_ram_hungry_jobs(),
     reference = config["reference"]["genome"],
@@ -201,9 +202,11 @@ rule base_recalibrator:
 rule bqsr_print_reads:
   input:
     bam = join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam"),
+    bai = join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal.bam.bai"),
     bqsr = join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal_bqsr.table")
   output:
-    join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal_bqsr.bam")
+    bam = temp(join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal_bqsr.bam")),
+    bai = temp(join(WORKDIR, "{prefix}_aligned_coordinate_sorted_dups_indelreal_bqsr.bai"))
   params:
     mem_gb = _mem_gb_for_ram_hungry_jobs(),
     reference = config["reference"]["genome"]
@@ -217,4 +220,4 @@ rule bqsr_print_reads:
   shell:
     "gatk -Xmx{params.mem_gb}g "
     "-T PrintReads -nct {threads} -R {params.reference} -I {input.bam} -BQSR {input.bqsr} "
-    "-o {output} 2> {log}"
+    "-o {output.bam} 2> {log}"

--- a/pipeline/qc.rules
+++ b/pipeline/qc.rules
@@ -16,11 +16,7 @@
 This file contains QC-related processing rules.
 """
 
-import glob
 from os.path import join
-
-def _get_all_fastq_files(_):
-    return glob.glob("%s/*.fastq.gz" % WORKDIR)
 
 rule fastqc:
   input:

--- a/pipeline/rna.rules
+++ b/pipeline/rna.rules
@@ -25,7 +25,11 @@ if _rna_exists():
       r2 = join(WORKDIR, "{prefix}_R2.fastq.gz"),
       done = config["reference"]["genome"] + ".done"
     output:
-      join(WORKDIR, "{prefix}Aligned.sortedByCoord.out.bam")
+      temp(join(WORKDIR, "{prefix}Aligned.sortedByCoord.out.bam")),
+      temp(join(WORKDIR, "{prefix}Log.final.out")),
+      temp(join(WORKDIR, "{prefix}Log.out")),
+      temp(join(WORKDIR, "{prefix}Log.progress.out")),
+      temp(join(WORKDIR, "{prefix}SJ.out.tab"))
     params:
       genome_dir = _STAR_GENOME_DIR,
       output_dir = WORKDIR,
@@ -58,7 +62,11 @@ if _rna_exists():
       r = join(WORKDIR, "{prefix}.fastq.gz"),
       done = config["reference"]["genome"] + ".done"
     output:
-      join(WORKDIR, "{prefix}Aligned.sortedByCoord.out.bam")
+      temp(join(WORKDIR, "{prefix}Aligned.sortedByCoord.out.bam")),
+      temp(join(WORKDIR, "{prefix}Log.final.out")),
+      temp(join(WORKDIR, "{prefix}Log.out")),
+      temp(join(WORKDIR, "{prefix}Log.progress.out")),
+      temp(join(WORKDIR, "{prefix}SJ.out.tab"))
     params:
       genome_dir = _STAR_GENOME_DIR,
       output_dir = WORKDIR,
@@ -91,7 +99,7 @@ if _rna_exists():
       expand(join(WORKDIR, "rna_{fragment_id}Aligned.sortedByCoord.out.bam"),
         fragment_id=_get_fragment_ids("rna"))
     output:
-      join(WORKDIR, "rna_merged_aligned_coordinate_sorted.bam")
+      temp(join(WORKDIR, "rna_merged_aligned_coordinate_sorted.bam"))
     benchmark:
       join(BENCHMARKDIR, "merge_rna_aligned_fragments.txt")
     log:
@@ -112,7 +120,7 @@ if _rna_exists():
     input:
       join(WORKDIR, "rna_aligned_coordinate_sorted_dups.bam")
     output:
-      join(WORKDIR, "rna_aligned_coordinate_sorted_dups_cigar_N_filtered.bam")
+      temp(join(WORKDIR, "rna_aligned_coordinate_sorted_dups_cigar_N_filtered.bam"))
     benchmark:
       join(BENCHMARKDIR, "rna_filter_N.txt")
     shell:
@@ -126,7 +134,7 @@ if _rna_exists():
     input:
       join(WORKDIR, "rna_aligned_coordinate_sorted_dups.bam")
     output:
-      join(WORKDIR, "rna_aligned_coordinate_sorted_dups_cigar_0-9MIDSHPX_filtered.bam")
+      temp(join(WORKDIR, "rna_aligned_coordinate_sorted_dups_cigar_0-9MIDSHPX_filtered.bam"))
     benchmark:
       join(BENCHMARKDIR, "rna_split_out_other.txt")
     shell:
@@ -140,7 +148,9 @@ if _rna_exists():
     input:
       join(WORKDIR, "{prefix}.bam")
     output:
-      bam = join(WORKDIR, "{prefix}_sorted.bam")
+      bam = temp(join(WORKDIR, "{prefix}_sorted.bam")),
+      bai = temp(join(WORKDIR, "{prefix}_sorted.bam.bai")),
+      tmpdir = temp(directory(join(WORKDIR, "{prefix}_sort_tmp")))
     params:
       output_dir = WORKDIR
     threads: _get_half_cores
@@ -156,6 +166,7 @@ if _rna_exists():
       "-o {output.bam} "
       "{input} "
       "2> {log}"
+  ruleorder: sort_rna_bam > sambamba_index_bam
 
   # run indel realignment on the reads without Ns
   rule rna_indel_realigner_per_chr:
@@ -194,8 +205,8 @@ if _rna_exists():
         bai = expand(join(WORKDIR, "rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal_chr_{chr}.bai"),
                      chr=config["contigs"])
       output:
-        bam = join(WORKDIR, "rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal.bam"),
-        bai = join(WORKDIR, "rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal.bam.bai")
+        bam = temp(join(WORKDIR, "rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal.bam")),
+        bai = temp(join(WORKDIR, "rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal.bam.bai"))
       benchmark:
         join(BENCHMARKDIR, "rna_indel_realigner_benchmark.txt")
       log:
@@ -209,8 +220,8 @@ if _rna_exists():
         bam = join(WORKDIR, "rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal_chr_ALL.bam"),
         bai = join(WORKDIR, "rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal_chr_ALL.bai")
       output:
-        bam = join(WORKDIR, "rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal.bam"),
-        bai = join(WORKDIR, "rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal.bam.bai")
+        bam = temp(join(WORKDIR, "rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal.bam")),
+        bai = temp(join(WORKDIR, "rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal.bam.bai"))
       benchmark:
         join(BENCHMARKDIR, "rna_indel_realigner.txt")
       log:
@@ -224,8 +235,19 @@ if _rna_exists():
       join(WORKDIR, "rna_cigar_0-9MIDSHPX_filtered_sorted_indelreal.bam"),
       join(WORKDIR, "rna_aligned_coordinate_sorted_dups_cigar_N_filtered_sorted.bam")
     output:
-      join(WORKDIR, "rna_final.bam")
+      bam = temp(join(WORKDIR, "rna_final.bam")),
+      bai = temp(join(WORKDIR, "rna_final.bam.bai"))
     benchmark:
       join(BENCHMARKDIR, "rna_final_merge.txt")
     shell:
-      "sambamba merge {output} {input}"
+      "sambamba merge {output.bam} {input}"
+
+  rule rename_and_protect_rna_bam:
+    input:
+      rna = join(WORKDIR, "rna_final_sorted.bam"),
+      rna_bai = join(WORKDIR, "rna_final_sorted.bam.bai")
+    output:
+      rna = protected(join(WORKDIR, "rna.bam")),
+      rna_bai = protected(join(WORKDIR, "rna.bam.bai"))
+    shell:
+      "cp {input.rna} {output.rna} && cp {input.rna_bai} {output.rna_bai}"

--- a/pipeline/special_sauce.rules
+++ b/pipeline/special_sauce.rules
@@ -36,8 +36,8 @@ if "mhc_alleles" in config["input"] and _rna_exists():
     rule vaxrank:
       input:
         vcfs = _get_vaxrank_input_vcfs,
-        rna = join(WORKDIR, "rna_final_sorted.bam"),
-        rna_index = join(WORKDIR, "rna_final_sorted.bam.bai")
+        rna = join(WORKDIR, "rna.bam"),
+        rna_index = join(WORKDIR, "rna.bam.bai")
       output:
         ascii_report = join(WORKDIR, "vaccine-peptide-report_{mhc_predictor}_{vcf_types}.txt"),
         json_file = join(WORKDIR, "vaccine-peptide-report_{mhc_predictor}_{vcf_types}.json"),

--- a/pipeline/variant_calling.rules
+++ b/pipeline/variant_calling.rules
@@ -18,6 +18,24 @@ def _get_cosmic_str():
   cosmic = config["reference"].get("cosmic", None)
   return "--cosmic " + cosmic if cosmic else ""
 
+rule rename_and_protect_dna_bams:
+  input:
+    normal = join(WORKDIR, "normal_aligned_coordinate_sorted_dups_indelreal_bqsr.bam"),
+    normal_bai = join(WORKDIR, "normal_aligned_coordinate_sorted_dups_indelreal_bqsr.bai"),
+    tumor = join(WORKDIR, "tumor_aligned_coordinate_sorted_dups_indelreal_bqsr.bam"),
+    tumor_bai = join(WORKDIR, "tumor_aligned_coordinate_sorted_dups_indelreal_bqsr.bai")
+  output:
+    normal = protected(join(WORKDIR, "normal.bam")),
+    normal_bai = protected(join(WORKDIR, "normal.bam.bai")),
+    tumor = protected(join(WORKDIR, "tumor.bam")),
+    tumor_bai = protected(join(WORKDIR, "tumor.bam.bai"))
+  run:
+    shell("""
+        cp {input.normal} {output.normal} && \
+        cp {input.normal_bai} {output.normal_bai} && \
+        cp {input.tumor} {output.tumor} && \
+        cp {input.tumor_bai} {output.tumor_bai}""")
+
 # run a separate mutect task for each chromosome
 #
 # If not running in a Docker image, user must have these environment variables set:
@@ -26,8 +44,8 @@ def _get_cosmic_str():
 # TODO(julia): this should go in the config instead of being set by env variables
 rule mutect_per_chr:
   input:
-    normal = join(WORKDIR, "normal_aligned_coordinate_sorted_dups_indelreal_bqsr.bam"),
-    tumor = join(WORKDIR, "tumor_aligned_coordinate_sorted_dups_indelreal_bqsr.bam")
+    normal = join(WORKDIR, "normal.bam"),
+    tumor = join(WORKDIR, "tumor.bam")
   output:
     temp(join(WORKDIR, "mutect_{chr}.vcf.idx")),
     temp(join(WORKDIR, "mutect_{chr}.vcf.out")),
@@ -62,14 +80,14 @@ rule mutect:
   input:
     expand(join(WORKDIR, "mutect_{chr}.vcf"), chr=config["contigs"])
   output:
-    join(WORKDIR, "mutect.vcf")
+    protected(join(WORKDIR, "mutect.vcf"))
   shell:
     "vcf-concat {input} > {output}"
 
 rule mutect2_per_chr:
   input:
-    normal = join(WORKDIR, "normal_aligned_coordinate_sorted_dups_indelreal_bqsr.bam"),
-    tumor = join(WORKDIR, "tumor_aligned_coordinate_sorted_dups_indelreal_bqsr.bam")
+    normal = join(WORKDIR, "normal.bam"),
+    tumor = join(WORKDIR, "tumor.bam")
   output:
     temp(join(WORKDIR, "mutect2_{chr}.vcf"))
   params:
@@ -96,7 +114,7 @@ rule mutect2:
   input:
     expand(join(WORKDIR, "mutect2_{chr}.vcf"), chr=config["contigs"])
   output:
-    join(WORKDIR, "mutect2.vcf")
+    protected(join(WORKDIR, "mutect2.vcf"))
   shell:
     "vcf-concat {input} > {output}"
 
@@ -105,11 +123,11 @@ rule mutect2:
 # - STRELKA_CONFIG: path to Strelka config file
 rule strelka:
   input:
-    normal = join(WORKDIR, "normal_aligned_coordinate_sorted_dups_indelreal_bqsr.bam"),
-    tumor = join(WORKDIR, "tumor_aligned_coordinate_sorted_dups_indelreal_bqsr.bam")
+    normal = join(WORKDIR, "normal.bam"),
+    tumor = join(WORKDIR, "tumor.bam")
   output:
-    expand(join(WORKDIR, "strelka_output/results/variants/somatic.{type}.vcf.gz"),
-      type=['snvs', 'indels'])
+    temp(expand(join(WORKDIR, "strelka_output/results/variants/somatic.{type}.vcf.gz"),
+      type=['snvs', 'indels']))
   params:
     output_dir = join(WORKDIR, "strelka_output"),
     reference = config["reference"]["genome"]
@@ -130,14 +148,16 @@ rule strelka:
     "./runWorkflow.py -m local -j {threads} "
     ">> {log} 2>&1"
 
+# This rule also deletes the Strelka output directory when it's done.
 rule strelka_combine:
   input:
     snvs = join(WORKDIR, "strelka_output/results/variants/somatic.snvs.vcf.gz"),
     indels = join(WORKDIR, "strelka_output/results/variants/somatic.indels.vcf.gz")
   output:
-    join(WORKDIR, "strelka.vcf")
+    protected(join(WORKDIR, "strelka.vcf"))
   params:
-    reference = config["reference"]["genome"]
+    reference = config["reference"]["genome"],
+    output_dir = join(WORKDIR, "strelka_output")
   benchmark:
     join(BENCHMARKDIR, "strelka_combine.txt")
   log:
@@ -150,13 +170,14 @@ rule strelka_combine:
     "-genotypeMergeOptions PRIORITIZE "
     "-o {output} "
     "-priority snvs,indels "
-    "2> {log}"
+    "2> {log} && "
+    "rm -rf {params.output_dir}"
 
 rule haplotype_caller_per_chr:
   input:
-    normal = join(WORKDIR, "normal_aligned_coordinate_sorted_dups_indelreal_bqsr.bam")
+    normal = join(WORKDIR, "normal.bam")
   output:
-    join(WORKDIR, "normal_germline_snps_indels_{chr}.vcf")
+    temp(join(WORKDIR, "normal_germline_snps_indels_{chr}.vcf"))
   params:
     reference = config["reference"]["genome"],
     dbsnp = config["reference"]["dbsnp"]


### PR DESCRIPTION
Additionally, renames the final BAM files to "normal.bam", "tumor.bam" and "rna.bam" (cleaner, shorter names)