### PR TITLE
Annotate VAFs in the all-passing-variants file

### DIFF
--- a/pipeline/scripts/annotate_variants.py
+++ b/pipeline/scripts/annotate_variants.py
@@ -96,7 +96,25 @@ def get_aligned_pairs_with_cigar(read):
     df['read_position'] = df['read_position'].astype(float)
     return df
 
-def annotate_from_vcf(vcf_file, variants_df, label, min_mapq=10):
+def annotate_from_vcf(vcf_file, variants_df, label):
+    """
+    Annotate allelic depths and VAFs from a VCF file.
+
+    Mutect / Mutect2 / Strelka all specify different fields in the VCF sample
+    info. In the case of strelka, the allelic depths and VAFs aren't provided,
+    so we do not extract that info.
+
+    We add the following columns:
+    - {label}_normal_ref_count - Reference allele count in normal sample
+    - {label}_normal_alt_count - Alternate allele count in normal sample
+    - {label}_normal_depth - Depth in normal sample
+    - {label}_normal_vaf - Variant allele frequency in normal sample
+    - {label}_tumor_ref_count - Reference allele count in tumor sample
+    - {label}_tumor_alt_count - Alternate allele count in tumor sample
+    - {label}_tumor_depth - Depth in tumor sample
+    - {label}_tumor_vaf - Variant allele frequency in tumor sample
+    - {label} - Boolean indicating whether the variant was found in the VCF file
+    """
     vcf = varcode.load_vcf(vcf_file)
     metadata = vcf.metadata
 

--- a/pipeline/scripts/annotate_variants.py
+++ b/pipeline/scripts/annotate_variants.py
@@ -1,0 +1,280 @@
+"""
+Count the reads supporting reference and alternate alleles for given variants in BAM files.
+
+Arguments:
+variants_file : str : CSV file containing variants with columns: contig, start, ref, alt. You can give the "all passing
+                    variants" file that vaxrank outputs here.
+--bam : str, str    : Label and path to BAM file (can be repeated for multiple BAM files)
+--output : str      : Output CSV file to save the results
+
+Example:
+python count_alleles_varcode_tqdm_rna.py \
+    variants.csv \
+    --bam normal_dna /path/to/tumor_rna.bam \
+    --bam tumor_rna /path/to/tumor_rna.bam \
+    --bam tumor_dna /path/to/tumor_dna.bam \
+    --output output_with_counts.csv
+
+Author: Tim O'Donnell, July 2024
+"""
+
+import pysam
+import numpy as np
+import pandas as pd
+import argparse
+from tqdm import tqdm
+
+import pysam
+import pandas as pd
+
+def get_aligned_pairs_with_cigar(read):
+    """
+    Get aligned pairs with the CIGAR operation and read sequence at each position.
+
+    Parameters:
+    read (pysam.AlignedSegment): A read from a BAM file.
+
+    Returns:
+    pd.DataFrame: A DataFrame containing the reference position, read position, CIGAR operation, and read base.
+    """
+    aligned_pairs = read.get_aligned_pairs(with_seq=False)
+    cigar_operations = read.cigartuples
+
+    # Create lists to hold the result
+    ref_positions = []
+    read_positions = []
+    cigar_ops = []
+    read_bases = []
+
+    # Variables to track the current position in the read and reference
+    read_index = 0
+
+    for operation, length in cigar_operations:
+        for _ in range(length):
+            if read_index < len(aligned_pairs):
+                read_pos, ref_pos = aligned_pairs[read_index]
+
+                if operation == 0:  # Match or mismatch
+                    cigar_op = 'M'
+                elif operation == 1:  # Insertion
+                    cigar_op = 'I'
+                elif operation == 2:  # Deletion
+                    cigar_op = 'D'
+                elif operation == 3:  # Skip (N)
+                    cigar_op = 'N'
+                elif operation == 4:  # Soft clipping
+                    cigar_op = 'S'
+                elif operation == 5:  # Hard clipping
+                    cigar_op = 'H'
+                elif operation == 6:  # Padding (P)
+                    cigar_op = 'P'
+                else:
+                    cigar_op = None
+
+                if read_pos is not None and read_pos < len(read.query_sequence):
+                    read_base = read.query_sequence[read_pos]
+                else:
+                    read_base = None
+
+                ref_positions.append(ref_pos)
+                read_positions.append(read_pos)
+                cigar_ops.append(cigar_op)
+                read_bases.append(read_base)
+
+                read_index += 1
+
+    df = pd.DataFrame({
+        'reference_position': ref_positions,
+        'read_position': read_positions,
+        'cigar_operation': cigar_ops,
+        'read_base': read_bases
+    })
+    df['reference_position'] = df['reference_position'].astype(float)
+    df['read_position'] = df['read_position'].astype(float)
+    return df
+def count_alleles(bam_file, variants_df, label, min_mapq=10):
+    """
+    Function to count reads supporting reference and alternate alleles for given variants in a BAM file.
+
+    Parameters:
+    bam_file (str): Path to the BAM file.
+    variants_df (pd.DataFrame): DataFrame containing variants with columns 'contig', 'start', 'ref', 'alt'.
+    label (str): Label for the BAM file (used to name the count columns).
+
+    Returns:
+    pd.DataFrame: DataFrame with additional columns for read counts and depth.
+    """
+    # Open the BAM file
+    bam = pysam.AlignmentFile(bam_file, "rb")
+
+    # index the bam if needed
+    if not bam.has_index():
+        print(f"Indexing {bam_file}")
+        pysam.index(bam_file)
+        bam = pysam.AlignmentFile(bam_file, "rb")
+
+    # Initialize new columns in the DataFrame
+    variants_df[f'{label}_ref_count'] = 0
+    variants_df[f'{label}_alt_count'] = 0
+    variants_df[f'{label}_depth'] = 0
+    variants_df[f'{label}_vaf'] = np.nan
+
+    # Iterate over each variant
+    for idx, row in tqdm(variants_df.iterrows(), total=variants_df.shape[0],
+            desc=f"Annotating {label}"):
+        contig = row['contig']
+        start = row['start']
+        ref = row['ref']
+        alt = row['alt']
+
+        ref_count = 0
+        alt_count = 0
+        total_depth = 0
+
+        # Deal with varcode name mangling
+        possible_contigs = [contig, "chr" + contig]
+        if contig == "MT":
+            possible_contigs.append("M")
+            possible_contigs.append("chrM")
+
+        correct_contig = None
+        reads = None
+        for possible_contig in possible_contigs:
+            try:
+                reads = bam.fetch(possible_contig, start - 1, start)
+                correct_contig = possible_contig
+                break
+            except ValueError:
+                pass
+        if correct_contig is None:
+            raise ValueError(
+                f"Could not find any of {possible_contigs} in BAM file {bam_file}. Valid contigs are: {bam.references}")
+
+        variants_df.at[idx, 'unmangled_contig'] = correct_contig
+
+        # Exclude reads with very low mapping quality or that are marked as duplicates.
+        reads = [read for read in reads if read.mapping_quality >= min_mapq]
+        reads = [read for read in reads if not read.is_duplicate]
+
+        if alt == "":
+            # Handle deletion
+            num_bases_deleted = len(ref)
+            for read in reads:
+                read_positions = get_aligned_pairs_with_cigar(read)
+                read_positions = read_positions.loc[
+                    (~read_positions.cigar_operation.isin(['N', 'S']))
+                ]
+
+                try:
+                    relevant_read_positions = read_positions.set_index("reference_position").loc[
+                        start - 1 :
+                        start - 1 + num_bases_deleted - 1
+                    ]
+                except KeyError:
+                    continue
+
+                if len(relevant_read_positions) > 0:
+                    total_depth += 1
+                    if relevant_read_positions.read_position.isnull().all():
+                        alt_count += 1
+                    elif (~relevant_read_positions.read_position.isnull()).all():
+                        ref_count += 1
+
+        elif ref == "":
+            # Handle insertion
+            for read in reads:
+                read_positions = get_aligned_pairs_with_cigar(read)
+                read_positions["reference_position"] = read_positions["reference_position"].fillna(method="ffill")
+                relevant_read_positions = read_positions.loc[
+                    (~read_positions.cigar_operation.isin(['N', 'S'])) &
+                    (read_positions.reference_position == start - 1)
+                ]
+                if len(relevant_read_positions) > 0:
+                    total_depth += 1
+                    read_sequence = "".join(relevant_read_positions.iloc[1:].read_base.fillna(""))
+                    if read_sequence == alt:
+                        alt_count += 1
+                    elif read_sequence == ref:
+                        ref_count += 1
+
+        else:
+            np.testing.assert_equal(len(ref), len(alt))
+            # Handle substitution
+            for read in reads:
+                read_positions = get_aligned_pairs_with_cigar(read)
+                read_positions["reference_position"] = read_positions["reference_position"].fillna(method="ffill")
+                relevant_read_positions = read_positions.loc[
+                    (~read_positions.cigar_operation.isin(['N', 'S'])) &
+                    (read_positions.reference_position >= start - 1) &
+                    (read_positions.reference_position < start - 1 + len(ref))
+                ]
+
+                if len(relevant_read_positions) > 0:
+                    total_depth += 1
+                    read_sequence = "".join(relevant_read_positions.read_base.fillna(""))
+                    if read_sequence == alt:
+                        alt_count += 1
+                    elif read_sequence == ref:
+                        ref_count += 1
+
+        # Update the counts and depth in the DataFrame
+        variants_df.at[idx, f'{label}_ref_count'] = ref_count
+        variants_df.at[idx, f'{label}_alt_count'] = alt_count
+        variants_df.at[idx, f'{label}_depth'] = total_depth
+        if total_depth > 0:
+            variants_df.at[idx, f'{label}_vaf'] = alt_count / total_depth
+
+    # Close the BAM file
+    bam.close()
+
+    return variants_df
+
+disclaimer = ("""
+*****************************
+Note: this script is a useful first-pass for annotating VAFs, but it is simplistic. It works directly with the
+alignments in the BAM and does not attempt to do any kind of realignment. That means it's not "seeing" the realigned version
+that e.g. mutect2 will be operating from. Especially for indels or variants with unexpectedly low VAFs you should
+manually check the results yourself in IGV. Also note that there may be discrepancies between what this script outputs
+and what you see in IGV due to differences in filters. This script counts reads with mapping quality at least 10 that
+are not marked as duplicates.
+*****************************
+""".strip())
+
+def main(variants_file, bam_files, output_file):
+    print(disclaimer)
+
+    # Load the variants DataFrame
+    variants_df = pd.read_csv(variants_file)
+
+    variants_df["contig"] = variants_df["contig"].astype(str)
+    variants_df["ref"] = variants_df["ref"].fillna("").astype(str)
+    variants_df["alt"] = variants_df["alt"].fillna("").astype(str)
+
+    if "gene_name" in variants_df.columns:
+        variants_df["gene_name"] = variants_df["gene_name"].fillna("").astype(str)
+
+    if "unmangled_contig" not in variants_df.columns:
+        variants_df["unmangled_contig"] = None
+
+    # Process each BAM file
+    for label, bam_path in bam_files:
+        variants_df = count_alleles(bam_path, variants_df, label)
+
+    # Save the updated DataFrame to the specified output file
+    variants_df.to_csv(output_file, index=False)
+    print(f'Wrote: {output_file}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Count alleles in BAM files for given variants.')
+    parser.add_argument('variants_file', type=str,
+        help='CSV file containing variants with columns: contig, start, ref, alt')
+    parser.add_argument('--bam', type=str, nargs=2, action='append',
+        required=True, help='Label and path to BAM file. Example: --bam tumor_rna /path/to/tumor.bam')
+    parser.add_argument('--output', type=str, required=True,
+        help='Output CSV file to save the results')
+
+    args = parser.parse_args()
+
+    main(args.variants_file, args.bam, args.output)

--- a/pipeline/special_sauce.rules
+++ b/pipeline/special_sauce.rules
@@ -37,11 +37,11 @@ if "mhc_alleles" in config["input"] and _rna_exists():
       input:
         vcfs = _get_vaxrank_input_vcfs,
         rna = join(WORKDIR, "rna.bam"),
-        rna_index = join(WORKDIR, "rna.bam.bai")
+        rna_index = join(WORKDIR, "rna.bam.bai"),
       output:
         ascii_report = join(WORKDIR, "vaccine-peptide-report_{mhc_predictor}_{vcf_types}.txt"),
         json_file = join(WORKDIR, "vaccine-peptide-report_{mhc_predictor}_{vcf_types}.json"),
-	# commenting this out for now: will need to figure out wkhtmltopdf install in Docker image
+	    # commenting this out for now: will need to figure out wkhtmltopdf install in Docker image
         #pdf_report = join(WORKDIR, "vaccine-peptide-report_{mhc_predictor}_{vcf_types}.pdf"),
         all_passing_variants = join(WORKDIR, "all-passing-variants_{mhc_predictor}_{vcf_types}.csv")
       params:
@@ -83,3 +83,24 @@ if "mhc_alleles" in config["input"] and _rna_exists():
             --min-alt-rna-reads {params.min_alt_rna_reads} \
             --mhc-epitope-lengths {params.mhc_epitope_lengths}
             """ % (vcf_input_str, ",".join(params.mhc_alleles)))
+
+    rule annotated_all_passing_variants:
+      input:
+        tumor_rna_bam = join(WORKDIR, "rna.bam"),
+        tumor_dna_bam = join(WORKDIR, "tumor.bam"),
+        normal_dna_bam = join(WORKDIR, "normal.bam"),
+        all_passing_variants = join(WORKDIR, "all-passing-variants_{mhc_predictor}_{vcf_types}.csv")
+      output:
+        annotated_all_passing_variants = join(WORKDIR, "annotated.all-passing-variants_{mhc_predictor}_{vcf_types}.csv")
+      log:
+        join(LOGDIR, "annotate_variants_{mhc_predictor}_{vcf_types}.log")
+      run:
+        _check_vaxrank_wildcards(wildcards)
+        shell("""
+            python $SCRIPTS/annotate_variants.py \
+                {input.all_passing_variants} \
+                --bam normal_dna {input.normal_dna_bam} \
+                --bam tumor_dna {input.tumor_dna_bam} \
+                --bam tumor_rna {input.tumor_rna_bam} \
+                --output {output.annotated_all_passing_variants}
+            """)

--- a/pipeline/special_sauce.rules
+++ b/pipeline/special_sauce.rules
@@ -37,7 +37,7 @@ if "mhc_alleles" in config["input"] and _rna_exists():
       input:
         vcfs = _get_vaxrank_input_vcfs,
         rna = join(WORKDIR, "rna.bam"),
-        rna_index = join(WORKDIR, "rna.bam.bai"),
+        rna_index = join(WORKDIR, "rna.bam.bai")
       output:
         ascii_report = join(WORKDIR, "vaccine-peptide-report_{mhc_predictor}_{vcf_types}.txt"),
         json_file = join(WORKDIR, "vaccine-peptide-report_{mhc_predictor}_{vcf_types}.json"),

--- a/pipeline/special_sauce.rules
+++ b/pipeline/special_sauce.rules
@@ -86,6 +86,7 @@ if "mhc_alleles" in config["input"] and _rna_exists():
 
     rule annotated_all_passing_variants:
       input:
+        vcfs = _get_vaxrank_input_vcfs,
         tumor_rna_bam = join(WORKDIR, "rna.bam"),
         tumor_dna_bam = join(WORKDIR, "tumor.bam"),
         normal_dna_bam = join(WORKDIR, "normal.bam"),
@@ -96,11 +97,13 @@ if "mhc_alleles" in config["input"] and _rna_exists():
         join(LOGDIR, "annotate_variants_{mhc_predictor}_{vcf_types}.log")
       run:
         _check_vaxrank_wildcards(wildcards)
+        vcf_input_str = ' '.join(['--vcf %s %s' % (x.split("/")[-1].replace(".vcf", ""), x) for x in input.vcfs])
         shell("""
             python $SCRIPTS/annotate_variants.py \
                 {input.all_passing_variants} \
                 --bam normal_dna {input.normal_dna_bam} \
                 --bam tumor_dna {input.tumor_dna_bam} \
                 --bam tumor_rna {input.tumor_rna_bam} \
+                %s \
                 --output {output.annotated_all_passing_variants}
-            """)
+            """ % vcf_input_str)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ tensorflow-cpu<=2.3.0
 mhcflurry
 numpy
 pandas
+ipdb
 jinja2==3.0.3

--- a/run_snakemake.py
+++ b/run_snakemake.py
@@ -201,8 +201,11 @@ def default_vaxrank_targets(config):
         get_output_dir(config),
         "vaccine-peptide-report_%s_%s" % (mhc_predictor, vcfs))
     # removed 'pdf' from this list until we install wkhtmltopdf in Docker image
-    return ['%s.%s' % (path_without_ext, ext) for ext in ('txt', 'json')]
-
+    return [
+        '%s.%s' % (path_without_ext, ext) for ext in ('txt', 'json')
+    ] + [
+        join(get_output_dir(config), f"annotated.all-passing-variants_{mhc_predictor}_{vcfs}.csv")
+    ]
 
 def somatic_vcf_targets(config):
     return [join(

--- a/run_snakemake.py
+++ b/run_snakemake.py
@@ -203,9 +203,12 @@ def default_vaxrank_targets(config):
     # removed 'pdf' from this list until we install wkhtmltopdf in Docker image
     return [
         '%s.%s' % (path_without_ext, ext) for ext in ('txt', 'json')
-    ] + [
-        join(get_output_dir(config), f"annotated.all-passing-variants_{mhc_predictor}_{vcfs}.csv")
     ]
+
+def annotated_vaxrank_targets(config):
+    mhc_predictor = config["mhc_predictor"]
+    vcfs = "-".join(config["variant_callers"])
+    return [join(get_output_dir(config), f"annotated.all-passing-variants_{mhc_predictor}_{vcfs}.csv")]
 
 def somatic_vcf_targets(config):
     return [join(
@@ -222,7 +225,7 @@ def get_and_check_targets(args, config):
         elif args.process_reference_only:
             targets = [config["reference"]["genome"] + ".done"]
         else:
-            targets = default_vaxrank_targets(config)
+            targets = default_vaxrank_targets(config) + annotated_vaxrank_targets(config)
     
     if len(targets) == 0:
         raise ValueError("Must specify at least one target")


### PR DESCRIPTION
This PR modifies the pipeline to additionally output a file with a name like:

annotated.all-passing-variants_mhcflurry_mutect-strelka-mutect2.csv

This file contains everything in the usual `all-passing-variants_mhcflurry_mutect-strelka-mutect2.csv` file but adds columns giving read counts for the re / alt, total depth, and VAFs, for normal dna / tumor dna / tumor rna.

The results mostly agree with what we see in IGV but you should check the results yourself rather than totally trusting these values. I added a disclaimer output message to the script for that reason:

```
Note: this script is a useful first-pass for annotating VAFs, but it is simplistic. It works directly with the
alignments in the BAM and does not attempt to do any kind of realignment. That means it's not "seeing" the realigned version
that e.g. mutect2 will be operating from. Especially for indels or variants with unexpectedly low VAFs you should
manually check the results yourself in IGV. Also note that there may be discrepancies between what this script outputs
and what you see in IGV due to differences in filters. This script counts reads with mapping quality at least 10 that
are not marked as duplicates.
```