### PR TITLE
patch vaxrank for failing wustl service

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -163,7 +163,8 @@ ENV SCRIPTS $HOME/pipeline/scripts
 RUN mkdir -p $HOME/.snakemake && sudo chown -R $USER $HOME/.snakemake
 
 # Hack to patch broken vaxrank after WUSTL server change.
-RUN sed -i '/^\s*except requests\.exceptions\.ConnectionError as e:/s/except requests\.exceptions\.ConnectionError as e:/except:/g' /home/user/miniconda/envs/mhcflurry/lib/python3.7/site-packages/vaxrank/report.py
-
+# This can be removed once vaxrank is fixed (and we update this image to latest vaxrank).
+# Replace specific exception handling with a generic "except Exception as e:" in report.py
+RUN sed -i '/^\s*except requests\.exceptions\.ConnectionError as e:/s/except requests\.exceptions\.ConnectionError as e:/except Exception as e:/g' /home/user/miniconda/envs/mhcflurry/lib/python3.7/site-packages/vaxrank/report.py
 
 ENTRYPOINT ["python", "run_snakemake.py"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -162,4 +162,8 @@ ENV SCRIPTS $HOME/pipeline/scripts
 # snakemake logs get written here (hidden dir)
 RUN mkdir -p $HOME/.snakemake && sudo chown -R $USER $HOME/.snakemake
 
+# Hack to patch broken vaxrank after WUSTL server change.
+RUN sed -i '/^\s*except requests\.exceptions\.ConnectionError as e:/s/except requests\.exceptions\.ConnectionError as e:/except:/g' /home/user/miniconda/envs/mhcflurry/lib/python3.7/site-packages/vaxrank/report.py
+
+
 ENTRYPOINT ["python", "run_snakemake.py"]


### PR DESCRIPTION
This is a hack to fix an issue in vaxrank that arose when WUSTL retired their web service: https://github.com/openvax/vaxrank/issues/204

Since vaxrank is pinned to an older version in this Docker image, we just patch the code for now. When we eventually update to current vaxrank we can remove this hack.